### PR TITLE
Appdata related changes

### DIFF
--- a/data/io.github.Foldex.AdwSteamGtk.appdata.xml.in
+++ b/data/io.github.Foldex.AdwSteamGtk.appdata.xml.in
@@ -43,7 +43,7 @@
 
   <releases>
     <release version="0.6.10" type="stable" date="2024-02-23">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Belarusian, Chinese, Dutch, Finnish, Hindi, Portuguese, Swedish, and Turkish Translations</li>
           <li>Updated German Translation</li>
@@ -53,7 +53,7 @@
       </description>
     </release>
     <release version="0.6.9" type="stable" date="2023-09-16">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Czech Translation</li>
           <li>Added Spanish Translation</li>
@@ -64,21 +64,21 @@
       </description>
     </release>
     <release version="0.6.8" type="stable" date="2023-07-30">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Fixed issue with Uninstall</li>
         </ul>
       </description>
     </release>
     <release version="0.6.7" type="stable" date="2023-07-30">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Removed Deprecated Font Install Preference</li>
         </ul>
       </description>
     </release>
     <release version="0.6.6" type="stable" date="2023-07-28">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Fixed Appdata</li>
           <li>Removed some options that no longer exist upstream</li>
@@ -86,7 +86,7 @@
       </description>
     </release>
     <release version="0.6.5" type="stable" date="2023-07-28">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Updated Russian Translation</li>
           <li>Updated to new upstream install method</li>
@@ -94,7 +94,7 @@
       </description>
     </release>
     <release version="0.6.4" type="stable" date="2023-07-15">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Updated German and Ukrainian Translations</li>
           <li>Added Portuguese Translation</li>
@@ -102,14 +102,14 @@
       </description>
     </release>
     <release version="0.6.3" type="stable" date="2023-06-16">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Fixed Appdata</li>
         </ul>
       </description>
     </release>
     <release version="0.6.2" type="stable" date="2023-06-16">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Beta Toggle removed as new UI support landed upstream</li>
           <li>Added option to use Steam's Original Top Bar instead of our Adwaita styled one</li>
@@ -119,14 +119,14 @@
       </description>
     </release>
     <release version="0.6.1" type="stable" date="2023-06-04">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added French, Ukrainian, and Russian Translations</li>
         </ul>
       </description>
     </release>
     <release version="0.6.0" type="stable" date="2023-05-27">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>New UI</li>
           <li>Added Experimental Beta Client Support (with new options)</li>
@@ -135,7 +135,7 @@
       </description>
     </release>
     <release version="0.5.0" type="stable" date="2023-05-03">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Autostart Update Check preference toggle</li>
           <li>Added Font Install preference toggle</li>
@@ -143,7 +143,7 @@
       </description>
     </release>
     <release version="0.4.1" type="stable" date="2023-04-16">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Fixed issue with theme preview on light mode</li>
           <li>Added preferences toggle for theme preview</li>
@@ -151,7 +151,7 @@
       </description>
     </release>
     <release version="0.4.0" type="stable" date="2023-04-15">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Colortheme is now previewed in app</li>
           <li>Added -u/-i arguments to install skin via commandline</li>
@@ -160,14 +160,14 @@
       </description>
     </release>
     <release version="0.3.0" type="stable" date="2023-04-02">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Library Sidebar Options</li>
         </ul>
       </description>
     </release>
     <release version="0.2.2" type="stable" date="2023-03-23">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Updated to Gnome 44 Runtime</li>
           <li>Changed Default Web Theme to Full Variant</li>
@@ -175,14 +175,14 @@
       </description>
     </release>
     <release version="0.2.1" type="stable" date="2023-03-04">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Fixed Installer CLI Output</li>
         </ul>
       </description>
     </release>
     <release version="0.2.0" type="stable" date="2023-01-05">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Color Theme Support</li>
           <li>Added -c argument to notify about updates</li>
@@ -190,7 +190,7 @@
       </description>
     </release>
     <release version="0.1.5" type="stable" date="2022-11-03">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Last chosen settings are now loaded at startup</li>
           <li>Changed display of install button if the theme is already installed</li>
@@ -198,14 +198,14 @@
       </description>
     </release>
     <release version="0.1.4" type="stable" date="2022-10-31">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added None to Window Control Options</li>
         </ul>
       </description>
     </release>
     <release version="0.1.3" type="stable" date="2022-10-15">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added QR Login Options</li>
           <li>Improved Missing Dir Messages</li>
@@ -213,7 +213,7 @@
       </description>
     </release>
     <release version="0.1.2" type="stable" date="2022-10-07">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Updated to Gnome 43 SDK</li>
           <li>Implemented AdwAboutWindow</li>

--- a/data/io.github.Foldex.AdwSteamGtk.appdata.xml.in
+++ b/data/io.github.Foldex.AdwSteamGtk.appdata.xml.in
@@ -12,6 +12,9 @@
   <name>AdwSteamGtk</name>
   <summary>Give Steam the Adwaita treatment</summary>
   <developer_name>Foldex</developer_name>
+  <developer id="io.github.Foldex">
+    <name>Foldex</name>
+  </developer>
 
   <url type="homepage">https://github.com/Foldex/AdwSteamGtk</url>
   <url type="bugtracker">https://github.com/Foldex/AdwSteamGtk/issues</url>


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer