### PR TITLE
Update color variable pattern to ignore `!important` (Fixes #78)

### DIFF
--- a/src/style.py
+++ b/src/style.py
@@ -45,7 +45,7 @@ def parse_css(file):
     with open (file, 'r' ) as f:
         content = f.read()
 
-    pattern = r'--([\w-]+)\s*:\s*(.*);'
+    pattern = r'--([\w-]+)\s*:\s*(.*?)(?:\s*!important)?;'
     matches = re.findall(pattern, content)
 
     vars = {}


### PR DESCRIPTION
Colors in color themes are now `!important` since [v3.2](https://github.com/tkashkin/Adwaita-for-Steam/releases/tag/3.2).