### PR TITLE
flatpak: Update manifest dependencies

### DIFF
--- a/io.github.Foldex.AdwSteamGtk.json
+++ b/io.github.Foldex.AdwSteamGtk.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.Foldex.AdwSteamGtk",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "adwaita-steam-gtk",
     "finish-args": [
@@ -31,8 +31,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v0.14.0/blueprint-compiler-v0.14.0.tar.bz2",
-                    "sha256": "2be7682be51b6cbd64ab6775ee6d5806bf18c599d503056eaa4e58f1705be22b",
+                    "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v0.16.0/blueprint-compiler-v0.16.0.tar.bz2",
+                    "sha256": "77a5d593f433c8ca70a05390532cd186c60944cfa6bcd39296c1c2597a7a50fc",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 279929,
@@ -54,8 +54,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/flatpak/libportal/archive/refs/tags/0.8.1.tar.gz",
-                    "sha256": "279cd848c41655964ea5109fd50ddf01ba414601d5265d1d16b8409ff54217f8",
+                    "url": "https://github.com/flatpak/libportal/archive/refs/tags/0.9.1.tar.gz",
+                    "sha256": "ea422b789ae487e04194d387bea031fd7485bf88a18aef8c767f7d1c29496a4e",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 230124,
@@ -73,8 +73,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/be/ec/2eb3cd785efd67806c46c13a17339708ddc346cbb684eade7a6e6f79536a/pyparsing-3.2.0-py3-none-any.whl",
-                    "sha256": "93d9577b88da0bbea8cc8334ee8b918ed014968fd2ec383e868fb8afb1ccef84",
+                    "url": "https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl",
+                    "sha256": "506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "pyparsing",


### PR DESCRIPTION
Fixes #86 

This patch bumps AdwSteamGtk to use the GNOME 48 SDK runtime :) 

This also fixes a compile error from blueprint compiler and reduces the warnings from libportal.