### PR TITLE
Custom CSS: Copy with default permissions

### DIFF
--- a/src/custom_css.py
+++ b/src/custom_css.py
@@ -47,4 +47,4 @@ def create():
         f.write(TEMPLATE)
 
 def install():
-    shutil.copy(paths.CUSTOM_CSS_FILE, paths.CUSTOM_CSS_FILE_DEST)
+    shutil.copyfile(paths.CUSTOM_CSS_FILE, paths.CUSTOM_CSS_FILE_DEST)


### PR DESCRIPTION
When the custom CSS file is read-only, it is also copied as read-only. When running the app multiple times, the following error occures:

```console
> adwaita-steam-gtk
Traceback (most recent call last):
  File "/nix/store/lgnawz4g5j5cq564cacva3s120bdylhq-adwsteamgtk-0.8.0/share/adwaita-steam-gtk/adwaita_steam_gtk/window.py", line 225, in install_theme
    (ret, msg) = install.run(options, self.beta_support)
                 ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/lgnawz4g5j5cq564cacva3s120bdylhq-adwsteamgtk-0.8.0/share/adwaita-steam-gtk/adwaita_steam_gtk/install.py", line 189, in run
    custom_css.install()
    ~~~~~~~~~~~~~~~~~~^^
  File "/nix/store/lgnawz4g5j5cq564cacva3s120bdylhq-adwsteamgtk-0.8.0/share/adwaita-steam-gtk/adwaita_steam_gtk/custom_css.py", line 50, in install
    shutil.copy(paths.CUSTOM_CSS_FILE, paths.CUSTOM_CSS_FILE_DEST)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/sd81bvmch7njdpwx3lkjslixcbj5mivz-python3-3.13.4/lib/python3.13/shutil.py", line 428, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/sd81bvmch7njdpwx3lkjslixcbj5mivz-python3-3.13.4/lib/python3.13/shutil.py", line 262, in copyfile
    with open(dst, 'wb') as fdst:
         ~~~~^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/home/bricked/.cache/AdwSteamInstaller/extracted/custom/custom.css'
```

This PR uses `shutil.copyfile` instead of `shutil.copy` in order to copy the CSS file with default permissions.